### PR TITLE
Fix: Correct API path for login request

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,5 +1,5 @@
 // Core API client configuration
-const BASE_URL = '/api'
+const BASE_URL = ''
 
 export interface ApiResponse<T> {
   data: T

--- a/src/services/dataService.ts
+++ b/src/services/dataService.ts
@@ -145,11 +145,11 @@ export const payrollService = {
 
 // Auth Services
 export const authService = {
-  login: (credentials: { email: string; password: string }) => 
+  login: (credentials: { email:string; password: string }) =>
     api.post<ApiResponse<{
       user: User
       session: { token: string; refreshToken: string; expiresAt: string }
-    }>>('/auth/login', credentials),
+    }>>('/api/auth/login', credentials),
   
   logout: () => api.post<ApiResponse<{ message: string }>>('/auth/logout'),
   


### PR DESCRIPTION
The login functionality was failing with a 404 error because the API request was being sent to an incorrect path. This was caused by a conflict between the relative `BASE_URL` in the API client and a script injected by the Lovable development environment.

This commit addresses the issue by:
1.  Setting the `BASE_URL` in `src/services/api.ts` to an empty string to prevent it from being prepended to all requests.
2.  Updating the `authService.login` function in `src/services/dataService.ts` to use the full, correct path `/api/auth/login`.

This ensures that the login request is sent to the correct endpoint and can be properly handled by the Mock Service Worker (MSW).