### PR TITLE
fix(msw): use base url for service worker path

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -20,7 +20,7 @@ async function startMSW() {
       await worker.start({
         onUnhandledRequest: 'bypass',
         serviceWorker: {
-          url: '/mockServiceWorker.js'
+          url: `${import.meta.env.BASE_URL}mockServiceWorker.js`,
         }
       })
       console.log('MSW service worker started successfully in', import.meta.env.MODE)


### PR DESCRIPTION
This fixes a bug where the Mock Service Worker (MSW) was failing to initialize in deployed preview environments.

The service worker path was hardcoded to an absolute path ('/mockServiceWorker.js'), which fails when the application is not served from the root of the domain.

This change prepends `import.meta.env.BASE_URL` to the service worker path in `src/main.tsx`. This ensures that the browser can always locate the `mockServiceWorker.js` file, allowing MSW to start correctly and intercept API calls as intended. This resolves the login issue where the frontend was receiving an HTML response instead of JSON.